### PR TITLE
adding functionality to call mainTimer through the updated interface

### DIFF
--- a/app/src/main/java/com/bedtime_audio_timer/audiotimer/MainActivity.kt
+++ b/app/src/main/java/com/bedtime_audio_timer/audiotimer/MainActivity.kt
@@ -101,7 +101,8 @@ class MainActivity : AppCompatActivity() {
     }
 
     fun startTimer(view: View)  {
-        //
+        val audioManager : AudioManager = getSystemService(AUDIO_SERVICE) as AudioManager
+        mainTimer(m_minutes, 60, audioManager)
     }
 
     private fun mainTimer(numMinutes: Int, numIntervals: Int, am: AudioManager){ //AudioManager argument needed for future audio behavior


### PR DESCRIPTION
Since the layout and buttons have changed and the original test button is gone, the function mainTimer was no longer being called by any button.  These changes fix that. Additionally, the value of numMinutes is taken from the stored user-input value.