### PR TITLE
Alignment of Moon Sliders on Timer Cancellation

### DIFF
--- a/app/src/main/java/com/bedtime_audio_timer/audiotimer/MainActivity.kt
+++ b/app/src/main/java/com/bedtime_audio_timer/audiotimer/MainActivity.kt
@@ -266,6 +266,7 @@ class MainActivity : AppCompatActivity(), MainTimer.TimerCallback, OutsideVolume
     }
 
     fun toggleTimer(view: View) { //suggesting this be renamed in the upcoming refactor to reflect fact that it now starts or stops timer (toggleTimer perhaps?)
+        VolumeSlider.realignMoons()
         if (mTimer?.isRunning()!!) {
             val myToast = Toast.makeText(this, "I will cancel", Toast.LENGTH_SHORT)
             myToast.show() //delete this Toast when interface makes cancellation clear.

--- a/app/src/main/java/com/bedtime_audio_timer/audiotimer/VolumeSlider.kt
+++ b/app/src/main/java/com/bedtime_audio_timer/audiotimer/VolumeSlider.kt
@@ -15,6 +15,10 @@ class VolumeSlider{
         lateinit var oldVolSeekBar: SeekBar
         lateinit var timerParams: TimerParameters
 
+        fun realignMoons(){
+            oldVolSeekBar.progress = greyedVolSeekBar.progress
+        }
+
         //since this function is no longer only called after timer cancel it should be renamed in near future.
         fun resetAfterTimerCancel(){
             timerParams.setVolume(targetVolSeekBar.progress)


### PR DESCRIPTION
The half moon slider (current volume) will now realign itself with the full moon slider when the timer is cancelled by user.