### PR TITLE
Toast modifications

### DIFF
--- a/app/src/main/java/com/bedtime_audio_timer/audiotimer/MainActivity.kt
+++ b/app/src/main/java/com/bedtime_audio_timer/audiotimer/MainActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.os.Handler
 import android.support.v7.app.AppCompatActivity
 import android.util.Log
+import android.view.Gravity
 import android.view.MotionEvent
 import android.view.View
 import android.widget.*
@@ -255,6 +256,7 @@ class MainActivity : AppCompatActivity(), MainTimer.TimerCallback, OutsideVolume
                 targetVolumeErrorMessage="Please pick a lower target volume"
             }
             val myToast=Toast.makeText(this, targetVolumeErrorMessage, Toast.LENGTH_SHORT)
+            myToast.setGravity(Gravity.CENTER,0,0)
             myToast.show()
         }
         else

--- a/app/src/main/java/com/bedtime_audio_timer/audiotimer/MainActivity.kt
+++ b/app/src/main/java/com/bedtime_audio_timer/audiotimer/MainActivity.kt
@@ -248,7 +248,13 @@ class MainActivity : AppCompatActivity(), MainTimer.TimerCallback, OutsideVolume
             Log.d("MainActivity ", "I will cancel")
 
         } else if (AudioManagerSingleton.am.getStreamVolume(AudioManager.STREAM_MUSIC) <= timerParams.getVolume()){  // Move to MainTimer!!!
-            val myToast = Toast.makeText(this, "Please pick a lower target volume", Toast.LENGTH_SHORT)
+            val targetVolumeErrorMessage : String
+            if (AudioManagerSingleton.am.getStreamVolume(AudioManager.STREAM_MUSIC)==0){
+                targetVolumeErrorMessage="Your phone is already hushed"
+            } else {
+                targetVolumeErrorMessage="Please pick a lower target volume"
+            }
+            val myToast=Toast.makeText(this, targetVolumeErrorMessage, Toast.LENGTH_SHORT)
             myToast.show()
         }
         else


### PR DESCRIPTION
Error message toast for invalid target volume (i.e., target volume chosen is same as system volume) now displays in center of screen instead of right over the start button.  Additionally, the error message displayed will depend on whether or not lowering the target volume is possible.  If it isn't possible, the app will tell the user their phone is already muted (or "hushed", in keeping with the app name).