### PR TITLE
fixing bug in behavior of moon sliders

### DIFF
--- a/app/src/main/java/com/bedtime_audio_timer/audiotimer/VolumeSlider.kt
+++ b/app/src/main/java/com/bedtime_audio_timer/audiotimer/VolumeSlider.kt
@@ -17,6 +17,10 @@ class VolumeSlider{
         lateinit var timerParams: TimerParameters
 
         fun realignMoons(){
+            val curVol=AudioManagerSingleton.am.getStreamVolume(AudioManager.STREAM_MUSIC)
+            if (greyedVolSeekBar.progress!=curVol){
+                greyedVolSeekBar.progress=curVol
+            }
             oldVolSeekBar.progress = greyedVolSeekBar.progress
             greyedVolSeekBar.setVisibility(View.INVISIBLE)
         }


### PR DESCRIPTION
Sometimes, depending on the user input and system volume, the half moon slider would wind up one increment above the current volume after the timer has finished.  These changes fix that bug by including a check for wrong position of half-moon in the realignMoons() function.  If the position of the half moon is not the current volume, realignMoons() will set the half moon's position to the current volume before changing the position of the full moon to match that of the half moon.